### PR TITLE
Test throw if `path` can't be found in `obj`

### DIFF
--- a/test/spec/interpolate.spec.js
+++ b/test/spec/interpolate.spec.js
@@ -42,6 +42,11 @@ describe('interpolate', function () {
     expect(render(data)).toMatch('JavaScript - AngularJS');
   });
 
+  it('should throw an error if `path` can\'t be extracted', function(){
+      var render = interpolate('{{ favourite["test"]["test"] }}');
+      expect(function(){ render(data); }).toThrow(new Error('Can\'t extract \'favourite["test"]["test"]\' from supplied object.'));
+  });
+
   it('should allow function call in the template', function() {
     var render = interpolate('Author: {{ fullName() }}.');
     var data = {


### PR DESCRIPTION
This PR needs #6. So merge that first. 
I just doesn't want to mix the lint cleanup and test adding. 
